### PR TITLE
Use relative paths instead of INIT_CWD in order to allow windows instalation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/radicle-dev/twemoji-svg-assets.git"
   },
   "scripts": {
-    "postinstall": "cp assets/svg/*.svg $INIT_CWD/public/twemoji/"
+    "postinstall": "cp assets/svg/*.svg ../../public/twemoji/"
   },
   "keywords": [
     "emoji",


### PR DESCRIPTION
[WIP] Preparing for fixes while trying to run `radicle-upstream` on Windows 

I'm opening pull requests earlier to document the effort needed to run Radicle Upstream on Windows - but feel free to wait for them all finished to evaluate the effort to maintain support.